### PR TITLE
Add Celo blockchain support to documentation

### DIFF
--- a/docs/payments/benefits.md
+++ b/docs/payments/benefits.md
@@ -26,7 +26,7 @@ It intelligently recommends the most **cost-efficient** and effective payment op
 
 ## Instant Multi-Blockchain Support
 
-Integrating DePay empowers your project to effortlessly support crypto payments across **10 blockchains**, **hundreds of wallets**, and **thousands of tokens** from day one.
+Integrating DePay empowers your project to effortlessly support crypto payments across **11 blockchains**, **hundreds of wallets**, and **thousands of tokens** from day one.
 
 Expand your user base and market reach instantly without additional integration effort.
 

--- a/docs/payments/donations/button.md
+++ b/docs/payments/donations/button.md
@@ -14,7 +14,7 @@ DePay's Web3 Donation Button allows you to directly accept Web3 Donations withou
 <div className="py-5">
   <DePayButton
     label={'Donate'}
-    blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base"]'
+    blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base","celo"]'
     configuration={ {"title": "Donation","accept":[{"blockchain":"ethereum","token":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"bsc","token":"0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"polygon","token":"0x2791bca1f2de4661ed88a30c99a7a9449aa84174","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"solana","token":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","receiver":"B2mgZ4ddUcu7bimLThBahpizPysVJ7xTd2woScmWtPYr"},{"blockchain":"gnosis","token":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"fantom","token":"0x28a92dde19D9989F39A49905d7C9C2FAc7799bDf","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"avalanche","token":"0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"arbitrum","token":"0xaf88d065e77c8cC2239327C5EDb3A432268e5831","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"optimism","token":"0x94b008aA00579c1307B0EF2c499aD98a8ce58e58","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"base","token":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"}]} }
   />
 </div>

--- a/docs/payments/integrate/button.md
+++ b/docs/payments/integrate/button.md
@@ -15,7 +15,7 @@ DePay's Web3 Payment Button allows you to directly accept Web3 Crypto Payments w
 <div className="py-5">
   <DePayButton
     label={'Pay'}
-    blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base"]'
+    blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base","celo"]'
     configuration={ {"accept":[{"blockchain":"ethereum","amount":1,"token":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"bsc","amount":1,"token":"0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"polygon","amount":1,"token":"0x2791bca1f2de4661ed88a30c99a7a9449aa84174","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"solana","amount":1,"token":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","receiver":"B2mgZ4ddUcu7bimLThBahpizPysVJ7xTd2woScmWtPYr"},{"blockchain":"gnosis","amount":1,"token":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"fantom","amount":1,"token":"0x28a92dde19D9989F39A49905d7C9C2FAc7799bDf","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"avalanche","amount":1,"token":"0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"arbitrum","amount":1,"token":"0xaf88d065e77c8cC2239327C5EDb3A432268e5831","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"optimism","amount":1,"token":"0x94b008aA00579c1307B0EF2c499aD98a8ce58e58","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"base","amount":1,"token":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"}]} }
   />
 </div>
@@ -25,7 +25,7 @@ DePay's Web3 Payment Button allows you to directly accept Web3 Crypto Payments w
   class="DePayButton"
   label="Pay"
   integration="1f517a0d-5bf3-4095-a096-c6b11d8e4d91"
-  blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base"]'
+  blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base","celo"]'
 ></div>
 <script src="https://integrate.depay.com/buttons/v13.js"></script>
 <noscript><a href="https://depay.com">Web3 Payments</a> are only supported with JavaScript enabled.</noscript>

--- a/docs/payments/protocol/deployments.md
+++ b/docs/payments/protocol/deployments.md
@@ -42,6 +42,10 @@ sidebar_position: 1
 
 [0x886eb82a7e5E7310F66A0E83748662A17E391eb0](https://worldscan.org/address/0x886eb82a7e5E7310F66A0E83748662A17E391eb0)<br/>
 
+###### Celo
+
+TODO: Deploy contracts on Celo
+
 ### Solana
 
 [DePayR1gQfDmViCPKctnZXNtUgqRwnEqMax8LX9ho1Zg](https://solscan.io/account/DePayR1gQfDmViCPKctnZXNtUgqRwnEqMax8LX9ho1Zg)<br/>

--- a/docs/payments/supported/blockchains.md
+++ b/docs/payments/supported/blockchains.md
@@ -31,6 +31,17 @@ The following blockchains are currently supported by DePay.
   </div>
 
   <div className="col-12 col-md-6">
+    <a href="#celo" className="d-flex hover-card p-3 align-items-center">
+      <div className="text-center position-relative pe-2" style={{width: "2.3rem"}}>
+        <img style={{ width: '1.8rem', height: '1.8rem', position: 'relative', top: '0.1rem' }} src="/docs/img/blockchains/Celo.svg"/>
+      </div>
+      <div className="ps-3 pt-1">
+        <div className="text-light"><strong>Celo</strong></div>
+      </div>
+    </a>
+  </div>
+
+  <div className="col-12 col-md-6">
     <a href="#gnosis" className="d-flex hover-card p-3 align-items-center">
       <div className="text-center position-relative pe-2" style={{width: "2.3rem"}}>
         <img style={{ width: '1.8rem', height: '1.8rem', position: 'relative', top: '0.1rem' }} src="/docs/img/blockchains/Gnosis.svg"/>
@@ -172,6 +183,14 @@ A payment transaction on Avalanche costs users approx. **below $0.01** in averag
 Payments on BNB Smart Chain typically take **5 seconds** in average to process and validate.
 
 A payment transaction on BNB Smart Chain costs users approx. between **$0.01-$0.05** in average.
+
+## Celo
+
+Celo is an EVM-compatible blockchain focused on mobile-first DeFi.
+
+Payments on Celo typically take **5 seconds** in average to process and validate.
+
+A payment transaction on Celo costs users approx. **below $0.01** in average.
 
 ## Ethereum
 

--- a/docs/payments/supported/exchanges.md
+++ b/docs/payments/supported/exchanges.md
@@ -16,7 +16,7 @@ The following decentralized exchanges are currently supported by DePay.
       </div>
       <div className="ps-3">
         <div className="text-light"><strong>Uniswap v3</strong></div>
-        <div className="text-light">Ethereum, BSC, Polygon, Optimism, Arbitrum, Base, Avalanche, World Chain, Gnosis</div>
+        <div className="text-light">Ethereum, BSC, Polygon, Optimism, Arbitrum, Base, Avalanche, World Chain, Gnosis, Celo</div>
       </div>
     </div>
   </div>

--- a/docs/payments/supported/index.md
+++ b/docs/payments/supported/index.md
@@ -17,7 +17,7 @@ Learn what blockchains, wallets, tokens & exchanges are supported by DePay.
       </div>
       <div className="ps-3 pt-1">
         <div className="text-light"><strong>Blockchains</strong></div>
-        <div className="text-light">10 Blockchains</div>
+        <div className="text-light">11 Blockchains</div>
       </div>
     </a>
   </div>

--- a/docs/payments/tips/button.md
+++ b/docs/payments/tips/button.md
@@ -14,7 +14,7 @@ DePay's Web3 Tip Button allows you to directly accept Web3 Tips without any requ
 <div className="py-5">
   <DePayButton
     label={'Tip'}
-    blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base"]'
+    blockchains='["ethereum","bsc","polygon","solana","gnosis","avalanche","arbitrum","optimism","base","celo"]'
     configuration={ {"title": "Tip", "accept":[{"blockchain":"ethereum","token":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"bsc","token":"0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"polygon","token":"0x2791bca1f2de4661ed88a30c99a7a9449aa84174","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"solana","token":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","receiver":"B2mgZ4ddUcu7bimLThBahpizPysVJ7xTd2woScmWtPYr"},{"blockchain":"gnosis","token":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"fantom","token":"0x28a92dde19D9989F39A49905d7C9C2FAc7799bDf","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"avalanche","token":"0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"arbitrum","token":"0xaf88d065e77c8cC2239327C5EDb3A432268e5831","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"optimism","token":"0x94b008aA00579c1307B0EF2c499aD98a8ce58e58","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"},{"blockchain":"base","token":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","receiver":"0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02"}]} }
   />
 </div>

--- a/docs/payments/validation/index.md
+++ b/docs/payments/validation/index.md
@@ -38,3 +38,4 @@ Different blockchains have varying benchmarks for what constitutes a "finalized"
 | Optimism   | 100    | 40s     |
 | Base       | 100    | 40s     |
 | Worldchain | 100    | 40s     |
+| Celo       | 1      | 5s      |

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -575,6 +575,15 @@ export default function Home() {
 
               <div className="pb-1 pt-1">
                 <div className="d-flex p-2 text-decoration-none">
+                  <img style={{ width: '1rem', height: '1rem', position: 'relative', top: '0.2rem' }} src="/docs/img/blockchains/Celo.svg"/>
+                  <div className="ps-3">
+                    <div className="text-light"><strong>Celo</strong></div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="pb-1 pt-1">
+                <div className="d-flex p-2 text-decoration-none">
                   <img style={{ width: '1rem', height: '1rem', position: 'relative', top: '0.2rem' }} src="/docs/img/blockchains/Base.svg"/>
                   <div className="ps-3">
                     <div className="text-light"><strong>Base</strong></div>

--- a/static/img/blockchains/Celo.svg
+++ b/static/img/blockchains/Celo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2500 2500">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FCFF52;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;}
+</style>
+<circle class="st0" cx="1250" cy="1250" r="1250"/>
+<path class="st1" d="M1949.3,546.2H550.7v1407.7h1398.7v-491.4h-232.1c-80,179.3-260.1,304.1-466.2,304.1c-284.1,0-514.2-233.6-514.2-517.5c0-284,230.1-515.6,514.2-515.6c210.1,0,390.2,128.9,470.2,312.1h228.1V546.2z"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add Celo to supported blockchains page with visual card and description
- Add Celo to Uniswap V3 supported exchanges list
- Update blockchain count from 10 to 11
- Add Celo to validation table (1 block, ~5s)
- Add Celo deployment placeholders
- Update button integration examples with Celo
- Add official Celo SVG logo
- Update homepage blockchain section

## Test plan
- [ ] Verify Celo card renders correctly on blockchains page
- [ ] Verify logo displays properly
- [ ] Check all example code snippets include Celo